### PR TITLE
CASMCMS-7662: Use zypper-patch.sh helper script to apply zypper patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp2:sles15sp2 as base
 # the runBuildPrep script at build time
 ARG CSM_SSH_KEYS_VERSION=@RPM_VERSION@
 
-RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/ hpe-csm-stable && zypper --non-interactive refresh -f
+RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/ hpe-csm-stable && zypper --non-interactive refresh
 RUN zypper in --no-confirm python3-devel python3-pip gcc libopenssl-devel openssh curl less catatonit rsync glibc-locale-base 
 
 RUN zypper in -f --no-confirm csm-ssh-keys-@RPM_VERSION@
@@ -34,10 +34,9 @@ RUN zypper in -f --no-confirm csm-ssh-keys-@RPM_VERSION@
 # zypper command
 RUN zypper al csm-ssh-keys
 
-RUN zypper --non-interactive refresh -f
 # Apply security patches
-RUN zypper patch -y --with-update --with-optional
-RUN zypper clean
+COPY zypper-refresh-patch-clean.sh /
+RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
 COPY requirements.txt constraints.txt /
 ENV LANG=C.utf8

--- a/zypper-refresh-patch-clean.sh
+++ b/zypper-refresh-patch-clean.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+################################################
+################################################
+#                  ACHTUNG!                    #
+#  THIS SCRIPT EXISTS IN MULTIPLE REPOS!!!!!   #
+#                                              #
+# If you make changes or fixes to it, please   #
+# be sure to do it for all other copies of it. #
+#                                              #
+################################################
+################################################
+
+# This script is intended to be copied into a Docker image and run,
+# in order to apply necessary patches (typically security patches).
+# Ideally it should come after all other zypper commands and RPM
+# installs (to avoid the case where you zypper install something later
+# and fail to apply security patches for it or its dependencies that
+# get pulled in).
+
+# Eventually the CMS team plans to replace this by using curated base
+# images instead, so this script is likely only a temporary measure.
+
+# Run with set -x to help with debugging
+set -x
+
+# Do a zypper refresh without -f, so we only refresh repos if needed
+zypper --non-interactive refresh
+
+# Apply necessary patches in a while loop. This is done because
+# the zypper patch command returns 103 when it has successfully applied
+# a patch to itself, but it needs to be re-run in order to apply the remaining
+# patches. 
+
+# I do not know if this is guaranteed to only happen a single time per execution,
+# so in the case of 103 return codes, we will retry up to 10 times before
+# failing.
+
+count=0
+while [ $count -lt 10 ]; do
+    # My inclination was to omit the --with-update flag, but I have seen builds
+    # fail because of Snyk vulnerabilities until I added that argument. I suspect
+    # there is lag time between when Snyk knows about a vulnerability and when
+    # zypper considers the update to be a security patch.
+    zypper --non-interactive patch --with-update
+    rc=$?
+
+    # If rc = 0, break out of the while loop
+    [ $rc -eq 0 ] && break
+
+    # If rc != 103, then this is a true failure
+    [ $rc -ne 103 ] && exit $rc
+
+    # If rc = 103, increment count and retry
+    let count+=1
+done
+
+# If count = 10, that means the zypper command never gave return code 0
+[ $count -eq 10 ] && exit 103
+
+# Finally, clean up package caches and metadata
+zypper --non-interactive clean -a
+exit $?


### PR DESCRIPTION
### TLDR
Put a script inside this repo which applies zypper patches (notably security patches), and then call this script from the Dockerfile. This script has the necessary logic added to avoid a build failure we have seen when zypper patch has to apply a security patch to itself. I have tested and verified that this change builds fine and applies the updates correctly.

### DETAILS
This PR was spawned because of a discussion in a recent PR review:
Cray-HPE/console-node#23 (comment)

We run the "zypper patch" command in several Dockerfiles in order to apply the latest security patches when building the docker images. In this way, we usually avoid Snyk scan failures. However, our current Dockerfiles do not handle the case where the "zypper patch" command exits with 103 return code.

That return code is not a failure. It means that the zypper command has had to patch itself, and needs to be run again in order to apply the remaining patches.

It is not difficult to add this logic to our Dockerfiles to handle this case, but it is ugly, because I don't know a way to elegantly check command return codes and run loops based on them (other than embedding that into the argument to bash -c, which gets very ugly very quickly). Therefore I wrote a helper script to simply:
1. zypper refresh
2. zypper patch until it passes, it fails with a non-103 return code, or it has been run 10 times.
3. zypper clean

I have named the script zypper-refresh-patch-clean.sh to make it very clear what it is doing.

Since we are following this same procedure for many of our Dockerfiles, I originally planned to put this script in the cms-meta-tools repo, as we originally created that repo as a place to put scripts which we use in different repos, to avoid having to maintain multiple copies of the same script. However, given the team decision that this is not desirable, I will instead make a local copy of this script in each affected repo. I have added language to the script to remind people that if they need to update it, then they need to be sure to do so for all other copies in the other repos.

The eventual plan that has been proposed is to have CMS create and maintain our own library of base images, which will be patched before being consumed by the Dockerfiles. At that time, we can consider retiring this script, but in the meantime we need this script to stop the kind of build failures that David saw when dealing with the PR linked at the very top of this text.