### PR TITLE
CASMCMS-7711: Update RPM repo URL to new location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp2:sles15sp2 as base
 # the runBuildPrep script at build time
 ARG CSM_SSH_KEYS_VERSION=@RPM_VERSION@
 
-RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/ hpe-csm-stable && zypper --non-interactive refresh
+RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/ hpe-csm-stable && zypper --non-interactive refresh
 RUN zypper in --no-confirm python3-devel python3-pip gcc libopenssl-devel openssh curl less catatonit rsync glibc-locale-base 
 
 RUN zypper in -f --no-confirm csm-ssh-keys-@RPM_VERSION@


### PR DESCRIPTION
## Summary and Scope

Recently the RPM repo layout on algol60 was changed. Previously all stable hpe RPMs were put into a single repo. The problem there was that this lumped together our RPMs build for different SLES versions. As a result, the repos were split out so that RPMs were published to a repo specific to their target OS. However, the previous repo was not removed. Therefore all builds pointing to it still worked...until one of them wanted to install a recent version of an RPM, one which was built and published using this new system, and therefore did not exist in the old repo.

That was the case for two of our repos -- ansible-execution-environment and csm-config. This PR just updates the repo URL in the Dockerfile to point to the updated repo location. This will fix the build breaks we are already seeing in csm-config and that we will eventually see in aee. I am making PRs for both csm-1.2 and csm-1.0, because if we do need to build new csm-1.0 versions of these repos, then this problem would still be there.

This is critical because it is actively causing csm-config build breaks and any day now will cause aee build breaks.

## Issues and Related PRs

Other PRs containing this bug fix:
* https://github.com/Cray-HPE/csm-config/pull/29
* https://github.com/Cray-HPE/csm-config/pull/31
* https://github.com/Cray-HPE/ansible-execution-environment/pull/16

And 2 for keeping the master branch up to date in those two repos, which include this bug fix:
* https://github.com/Cray-HPE/csm-config/pull/30
* https://github.com/Cray-HPE/ansible-execution-environment/pull/18

## Testing

The only testing I did was verify that the builds worked, specifically verifying that the updated repo URL was being used and the RPM was being installed successfully.

## Risks and Mitigations

In the case of csm-config, there is no risk, since it won't even build right now.
In the case of aee, the risk is very low, due to the nature of the change being made. If this results in a problem, it is almost certainly a problem with the RPM being installed, not with aee or this PR.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

