### PR TITLE
Switch to SP3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #
 # (MIT License)
 
-FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp2:sles15sp2 as base
+FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.3 as base
 
 # Pin the version of csm-ssh-keys being installed. The actual version is substituted by
 # the runBuildPrep script at build time


### PR DESCRIPTION
## Summary and Scope

Update AEE to SLES 15 SP3 for a base to bring in double fresh goodness. Backwards compatible

## Issues and Related PRs

* Resolves [CASMTRIAGE-2853](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2853)
* Change will also be needed in Cray-HPE/cfs-operator chart

## Testing

### Tested on:

  * `hela`

### Test description:

@spillerc-hpe ran an image customization with the new AEE after it was added on the system and the cfs-operator was configured to use it. Ansible was able to connect to the image root setup by IMS.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

N/A this probably removes risk by upgrading to a newer version of SLES 15.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
