### PR TITLE
CASMCMS-7784: Add flag for disabled component state recording

### DIFF
--- a/callback_plugins/cfs_aggregator.py
+++ b/callback_plugins/cfs_aggregator.py
@@ -1,4 +1,7 @@
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -12,13 +15,11 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-#
-# (MIT License)
 
 import os
 import redis
@@ -112,7 +113,8 @@ class CallbackModule(CallbackBase):
             self.make_failed(host)
 
     def v2_playbook_on_stats(self, stats):
-        if os.environ.get('INVENTORY_TYPE', '') != 'image':
+        disable_state_recording = (os.environ.get('DISABLE_STATE_RECORDING', 'false').lower() == 'true')
+        if not disable_state_recording:
             handler = CfsComponentsHandler()
             handler.update_component_status(stats)
 


### PR DESCRIPTION
## Summary and Scope

Adds a new flag for disabling component state recording.  This is to support a new parameter for CFS to allow sessions to be created with arbitrary arguments passed to Ansible.

## Issues and Related PRs

* Resolves CASMCMS-7784

## Testing

### Tested on:

  * Wasp

### Test description:

Ran CFS sessions without passthrough parameters, and with different combinations of parameters.  Also tested image customization since the disabling of state recording during image customization was moved to using the new parameter.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

