### PR TITLE
CASMCMS-8029: Explicitly set permission bits during AEE setup

### DIFF
--- a/entrypoint-setup.sh
+++ b/entrypoint-setup.sh
@@ -53,11 +53,13 @@ fi
 echo "Inventory generation completed"
 
 mkdir -p /root/.ssh
+chmod 600 /inventory/ssh/id_ecdsa
 cp -a /inventory/ssh/* /root/.ssh
 chmod 600 /root/.ssh/id_ecdsa
 echo "SSH keys migrated to /root/.ssh"
 
 cp -r /inventory/* /etc/ansible/
+chmod 600 /etc/ansible/ssh/id_ecdsa
 
 if [ ! -d "${GROUPVARS_DIR}" ]; then
   mkdir $GROUPVARS_DIR


### PR DESCRIPTION
User set umask values apparently affect the overall run pod execution of containers deployed on worker nodes. When a user changes the default umask for the system, newly copied files inherit the permission mask as set. This prevents the ansible-execution-environment inventory layer from correctly providing a suitable key file to use to connect with nodes. The issue is further complicated by the migration to non-root containers, which provides the key file mount in variable ways based on the overall version of the CFS release. By setting the bits explicitly to known accepted values, we have a solution that works in all known releases.

* Resolves [CASMCMS-8029](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8029)
* Change will also be needed in `csm-1.2`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

