### PR TITLE
CASMCMS-7714: Add playbook info to ansible container logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ associated Anisble Execution Environment (AEE). For more information about what
 this does, see the README.md entry.
 
 ## [Unreleased]
+### Added
+- Added playbook information to the ansible container logs
+
 ### Changed
 - Spelling corrections.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,8 @@ if [ $? -ne 0 ]; then
     exit;
 fi
 
+echo "Running $SESSION_PLAYBOOK from repo $SESSION_CLONE_URL"
+
 "$@" 2>&1
 ANSIBLE_EXIT=$?
 


### PR DESCRIPTION
## Summary and Scope

Add additional output in the Ansible log to record the playbook name and git source for easier debugging

## Issues and Related PRs

* Resolves CASMCMS-7714

## Testing

### Tested on:

  * Starlord

### Test description:

Ran a session and verified the output

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

