### PR TITLE
CASMCMS-7690: Add ARA to aee image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ this does, see the README.md entry.
 
 ## [Unreleased]
 ### Added
+- Added the ARA plugin
 - Added playbook information to the ansible container logs
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,10 @@ COPY /strategy_plugins/*            /usr/share/ansible/plugins/strategy/
 COPY /modules/*                     /usr/share/ansible/plugins/modules/
 RUN mv /opt/cray/ansible/modules/*    /usr/share/ansible/plugins/modules/
 
+# Stage ARA plugins
+RUN mkdir -p /usr/share/ansible/plugins/ara/
+RUN cp $(python3 -m ara.setup.callback_plugins)/*.py /usr/share/ansible/plugins/ara/
+
 # Stage our default ansible variables
 COPY cray_ansible_defaults.yaml /
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,5 @@
 ansible==2.9.13
+ara==1.5.8
 asn1crypto==0.24.0
 bcrypt==3.1.6
 certifi==2019.11.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -c constraints.txt
 ansible
+ara
 dnspython
 hvac
 kubernetes


### PR DESCRIPTION
## Summary and Scope

Adds the ARA plugin for collecting Ansible logs to the AEE image.  By itself this change will have no effect.  The Ansible config will require a change to include the new plugin.

## Issues and Related PRs

* Resolves CASMCMS-7690

## Testing

### Tested on:

  * Mug

### Test description:

Successfully ran Ansible with and without log collection enabled.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

