### PR TITLE
Add a new ansible module from galaxy and fix builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ this does, see the README.md entry.
 
 ## Unreleased
 
+## [1.15.2] - 2023-10-24
+### Added
+- Added ansible.netcommon module for UAN use
+
+
 ## [1.15.1] - 2023-09-27
 ### Added
 - Tuneables for SOPS that support use of vars collection and hashicorp vault

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN pip3 install --no-cache-dir -U pip wheel && \
     pip3 install --no-cache-dir -r requirements.txt && \
     find . -iname '/opt/cray/ansible/requirements/*.txt' -exec  pip3 install --no-cache-dir -r "{}" \;
 
-# Stage our runtime configuration
+# Stage our buildtime configuration
 COPY ansible.cfg /etc/ansible/
 
 # Stage our custom plugins
@@ -70,7 +70,8 @@ RUN ansible-galaxy collection install community.sops:$COMMUNITY_SOPS_VERSION && 
     ansible-galaxy collection install ansible.utils && \
     ansible-galaxy collection install community.crypto && \
     ansible-galaxy collection install containers.podman && \
-    ansible-galaxy collection install community.libvirt
+    ansible-galaxy collection install community.libvirt && \
+    ansible-galaxy collection install ansible.netcommon
 
 # Stage our default ansible variables
 COPY cray_ansible_defaults.yaml /

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -514,6 +514,9 @@ pipelining = True
 # Set how many context lines to show in diff
 # context = 3
 
+[galaxy]
+server = https://old-galaxy.ansible.com/
+
 [community.sops]
 vars_stage = all
 vars_cache = true


### PR DESCRIPTION
## Summary and Scope

Fixes a build issue in AEE from an upstream galaxy change, adds a new module for the UAN config (ansible-netcommon).

## Issues

* Resolves [CASMTRIAGE-6198](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6198)
* Requires rebuild of cfs-operator to pick up new image

### Tested on:

  * Local development environment
  * Jenkins build system

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] CHANGELOG.md updated

