### PR TITLE
Add s3 module to ansible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ this does, see the README.md entry.
 ## [1.15.3] - 2023-10-26
 ### Added
 - aws_s3 ansible galaxy collection for s3 projection
+### Changed
+- Updated the formatting of ansible-modules into a single alphabetical invocation.
 
 ## [1.15.2] - 2023-10-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ this does, see the README.md entry.
 
 ## Unreleased
 
+## [1.15.3] - 2023-10-26
+### Added
+- aws_s3 ansible galaxy collection for s3 projection
+
 ## [1.15.2] - 2023-10-24
 ### Added
 - Added ansible.netcommon module for UAN use
-
 
 ## [1.15.1] - 2023-09-27
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,16 +62,19 @@ RUN cp $(python3 -m ara.setup.callback_plugins)/*.py /usr/share/ansible/plugins/
 
 # Add community modules and pre-install necessary binaries to support them from the distro
 RUN curl -L --output sops.rpm ${SOPS_RPM_SOURCE} && rpm -ivh sops.rpm
-RUN ansible-galaxy collection install community.sops:$COMMUNITY_SOPS_VERSION && \
-    ansible-galaxy collection install community.general && \
-    ansible-galaxy collection install community.hashi_vault:5.0.0 && \
-    ansible-galaxy collection install kubernetes.core && \
-    ansible-galaxy collection install ansible.posix && \
-    ansible-galaxy collection install ansible.utils && \
-    ansible-galaxy collection install community.crypto && \
-    ansible-galaxy collection install containers.podman && \
-    ansible-galaxy collection install community.libvirt && \
-    ansible-galaxy collection install ansible.netcommon
+RUN ansible-galaxy collection install  \
+        amazon.aws:5.2.0 \
+        ansible.netcommon \
+        ansible.posix \
+        ansible.utils \
+        containers.podman \
+        community.crypto \
+        community.general \
+        community.hashi_vault:3.0.0 \
+        community.libvirt \
+        community.sops:$COMMUNITY_SOPS_VERSION \
+        kubernetes.core
+
 
 # Stage our default ansible variables
 COPY cray_ansible_defaults.yaml /


### PR DESCRIPTION
## Summary and Scope

Internal repositories require aws_s3 ansible module, which is not part of ansible.common.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6217](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6217)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Local development environment

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
