### PR TITLE
CASMCMS-8896 - changes for remote IMS jobs.

### DIFF
--- a/entrypoint-setup.sh
+++ b/entrypoint-setup.sh
@@ -80,3 +80,7 @@ do
   sleep 3
 done
 echo Sidecar available
+
+echo "Pausing for ims ssh servers to come up..."
+sleep 60
+echo "Proceeding"


### PR DESCRIPTION
## Summary and Scope

For IMS remote jobs, when the inventory container is complete, the ssh connection in the ansible container still does not work. I don't know what is still happening, but adding a 60 sec pause makes everything work.

I am NOT expecting this to be the 'final' fix. A better fix would be for the inventory container to do a full ssh test and wait for the connection to work. In the remote case there are really 2 ssh servers - one in the k8s job pod, and another on the remote node. They both need to be up and functioning before the complete ssh command work. 

This PR is more a placeholder to talk about it, as well as documenting A way to make it work currently...

## Issues and Related PRs
* Resolves [CASMCMS-8896](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8896)

## Testing
### Tested on:
  * `Mug`

### Test description:

Deployed the test image on Mug and changed the cfs-operator config map to use it. I then ran cfs image customizations with this ansible image and traced through the workflow - manually checking the results.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very risky - need discussion with the friendly CFS folks.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable

