### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ this does, see the README.md entry.
 
 ## Unreleased
 
+### Dependencies
+- Bumped `kubernetes` from 11.0.0 to 22.6.0 to match CSM 1.6 Kubernetes version
+- Bumping `kubernetes` necessitated bumping `openshift` from 0.11.2 to 0.13.2
+
 ## [1.15.3] - 2023-10-26
 ### Added
 - aws_s3 ansible galaxy collection for s3 projection

--- a/constraints.txt
+++ b/constraints.txt
@@ -11,10 +11,11 @@ hvac==0.9.6
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.5
-kubernetes==11.0.0
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 MarkupSafe==1.1.1
 netaddr==0.7.20
-openshift==0.11.2
+openshift==0.13.2
 paramiko==2.7.2
 pexpect==4.6.0
 ptyprocess==0.6.0


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.
