### PR TITLE
CASMTRIAGE-6799: Fixed loading kubernetes configuration data in the shasta_s3_creds module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ this does, see the README.md entry.
 
 ## Unreleased
 
+## [1.16.2] - 2024-03-20
+### Fixed
+- Fixed loading kubernetes configuration data in the shasta_s3_creds module
+
 ## [1.16.1] - 2024-02-22
 ### Dependencies
 - Bumped `csm-ssh-keys` from 1.5 to 1.6 for CSM 1.6

--- a/modules/shasta_s3_creds.py
+++ b/modules/shasta_s3_creds.py
@@ -31,8 +31,6 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from kubernetes import client, config
-from kubernetes.client.api_client import ApiClient
-from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 from kubernetes.config.config_exception import ConfigException
 
@@ -127,9 +125,7 @@ def run_module():
     except ConfigException:
         config.load_kube_config()
 
-    configuration = Configuration()
-    k8sclient = ApiClient(configuration=configuration)
-    coreapi = client.CoreV1Api(k8sclient)
+    coreapi = client.CoreV1Api()
 
     # Read the secret
     try:

--- a/modules/shasta_s3_creds.py
+++ b/modules/shasta_s3_creds.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope
Fixed an issue causing connection issues in csm-1.6 when using the shasta_s3_creds module.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6799

## Testing

### Tested on:

  * Partially tested on gamora

### Test description:

Updated and confirmed this code path worked.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

