### PR TITLE
CASMCMS-9115: Avoid curl version with known bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ this does, see the README.md entry.
 
 ## [Unreleased]
 
+## [1.17.1] - 2024-08-23
+
+### Changed
+- Add code to avoid curl versions due to a [known bug with that version](https://github.com/curl/curl/issues/13229)
+
 ## [1.17.0] - 2024-08-22
 
 ### Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,16 @@
 #
 FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.6 AS base
 
-# Set the SLES SP number
+# Set the SLES SP number and hardware architecture
 ARG SP=6
+ARG ARCH=x86_64
+
 # Pin the version of csm-ssh-keys being installed. The actual version is substituted by
 # the runBuildPrep script at build time
 ARG CSM_SSH_KEYS_VERSION=@RPM_VERSION@
 ARG SOPS_VERSION=3.6.1
 ARG SOPS_REBUILD_ID=1
-ARG SOPS_RPM_SOURCE=https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-${SOPS_REBUILD_ID}.x86_64.rpm
+ARG SOPS_RPM_SOURCE=https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-${SOPS_REBUILD_ID}.${ARCH}.rpm
 ARG COMMUNITY_SOPS_VERSION=1.6.6
 
 # Do zypper operations using a wrapper script, to isolate the necessary artifactory authentication

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,7 +28,7 @@
 # and scrubs the zypper environment after the necessary operations are completed.
 
 # Preconditions:
-# 1. Following variables have been set in the Dockerfile: SP CSM_SSH_KEYS_VERSION
+# 1. Following variables have been set in the Dockerfile: SP ARCH CSM_SSH_KEYS_VERSION
 # 2. zypper-refresh-patch-clean.sh script has also been copied into the current directory
 
 # Based in part on: https://github.com/Cray-HPE/uai-images/blob/main/uai-images/broker_uai/zypper.sh
@@ -44,19 +44,106 @@ CREDS=${ARTIFACTORY_USERNAME:-}
 [[ -z ${ARTIFACTORY_PASSWORD} ]] || CREDS="${CREDS}:${ARTIFACTORY_PASSWORD}"
 CSM_SLES_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
 CSM_NOOS_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic"
+SLES_MIRROR_URL="https://${CREDS}@artifactory.algol60.net/artifactory/sles-mirror"
+SLES_PRODUCTS_URL="${SLES_MIRROR_URL}/Products"
+SLES_UPDATES_URL="${SLES_MIRROR_URL}/Updates"
 
-zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URI}" csm-sles
-zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URI}" csm-noos
-zypper --non-interactive --gpg-auto-import-keys refresh
-zypper --non-interactive in --no-confirm python311-devel python311-pip gcc libopenssl-devel openssh curl less catatonit rsync glibc-locale-base jq
-zypper --non-interactive in -f --no-confirm csm-ssh-keys-${CSM_SSH_KEYS_VERSION}
+function run_cmd_retry
+{
+    local num rc
+    num=0
+    while [[ $num -lt 5 ]]; do
+        [[ $num -eq 0 ]] || sleep 5
+        echo "# $*"
+        "$@" && return 0 || rc=$?
+        echo "Command failed with rc $rc"
+        let num+=1
+    done
+    echo "Command failed even after retries"
+    return $rc
+}
+
+function add_zypper_repos {
+    local label repo_sp
+    label=$1
+    if [[ $# -eq 2 ]]; then
+        repo_sp=$2
+    else
+        repo_sp=${SP}
+    fi
+    run_cmd_retry zypper --non-interactive ar "${SLES_PRODUCTS_URL}/SLE-${label}/15-SP${repo_sp}/${ARCH}/product/?auth=basic" "sles15sp${repo_sp}-${label}-product"
+    run_cmd_retry zypper --non-interactive ar "${SLES_UPDATES_URL}/SLE-${label}/15-SP${repo_sp}/${ARCH}/update/?auth=basic" "sles15sp${repo_sp}-${label}-update"
+}
+
+function remove_zypper_repos {
+    local label repo_sp
+    label=$1
+    if [[ $# -eq 2 ]]; then
+        repo_sp=$2
+    else
+        repo_sp=${SP}
+    fi
+    run_cmd_retry zypper --non-interactive rr "sles15sp${repo_sp}-${label}-product"
+    run_cmd_retry zypper --non-interactive rr "sles15sp${repo_sp}-${label}-update"
+}
+
+if [[ ${SP} -lt 5 ]]; then
+    # The mirrors for these earlier SLES SPs are no longer available
+    echo "ERROR: SP == $SP, but must be 5+" >&2
+    exit 1
+fi
+
+run_cmd_retry zypper --non-interactive rr --all
+run_cmd_retry zypper --non-interactive clean -a
+
+for MODULE in Basesystem Certifications Containers Development-Tools Python3; do
+    add_zypper_repos "Module-${MODULE}"
+done
+
+#############################################################################
+# curl bug workaround
+#############################################################################
+
+# There is a bug in curl that breaks some operations
+# https://github.com/curl/curl/issues/13229
+# We know that it is not yet present in curl v8.5 and is fixed in v8.8.
+# The current SP6 repos don't have a version without this problem. So we add
+# an SP5 repo to pull in a good version of it
+S=5
+while [[ $S -lt $SP ]]; do
+    add_zypper_repos Module-Basesystem "$S"
+    let S+=1
+done
+run_cmd_retry zypper --non-interactive --gpg-auto-import-keys refresh
+
+# First try to install a newer version and then, failing that, an older one
+zypper --non-interactive in --force-resolution --no-confirm --no-recommends 'curl>=8.8' libopenssl1_1 || \
+    zypper --non-interactive in --force-resolution --no-confirm --oldpackage --no-recommends 'curl<8.6' libopenssl1_1
+
+# And then lock it so we don't change the version later
+run_cmd_retry zypper --non-interactive al curl
+
+# Remove the backlevel repo(s) so we don't pull other images from it
+S=5
+while [[ $S -lt $SP ]]; do
+    remove_zypper_repos Module-Basesystem "$S"
+    let S+=1
+done
+#############################################################################
+
+run_cmd_retry zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URI}" csm-sles
+run_cmd_retry zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URI}" csm-noos
+run_cmd_retry zypper --non-interactive --gpg-auto-import-keys refresh
+run_cmd_retry zypper --non-interactive in --no-confirm python311-devel python311-pip gcc libopenssl-devel openssh less catatonit rsync glibc-locale-base jq
+run_cmd_retry zypper --non-interactive in -f --no-confirm csm-ssh-keys-${CSM_SSH_KEYS_VERSION}
 # Lock the version of csm-ssh-keys, just to be certain it is not upgraded inadvertently somehow later
-zypper --non-interactive al csm-ssh-keys
+run_cmd_retry zypper --non-interactive al csm-ssh-keys
 # Apply security patches (this script also does a zypper clean)
 ./zypper-refresh-patch-clean.sh
 # Remove all repos & scrub the zypper directory 
-zypper --non-interactive rr --all
+run_cmd_retry zypper --non-interactive rr --all
 rm -f /etc/zypp/repos.d/*
+
 # Manually set the links that SLES neglects to do for us
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 99
 update-alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 99

--- a/zypper-refresh-patch-clean.sh
+++ b/zypper-refresh-patch-clean.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -64,7 +64,7 @@ while [ $count -lt 10 ]; do
     # fail because of Snyk vulnerabilities until I added that argument. I suspect
     # there is lag time between when Snyk knows about a vulnerability and when
     # zypper considers the update to be a security patch.
-    zypper --non-interactive patch --with-update
+    zypper --non-interactive patch --with-update --skip-not-applicable-patches
     rc=$?
 
     # If rc = 0, break out of the while loop


### PR DESCRIPTION
Moving the Docker image to SLES15SP6 led to a newer version of curl, one with a known bug:
https://github.com/curl/curl/issues/13229

There is a version of curl with that bug fixed, but it isn't available in our SLES mirrors yet. So this adds code to use a curl version without the bug. First it looks for one where it is fixed. If that fails, it then uses an older version of curl, where the bug does not yet exist.

I tested this on mug.