### PR TITLE
Remove cruft around vault token lookup and application.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ associated Anisble Execution Environment (AEE). For more information about what
 this does, see the README.md entry.
 
 ## [Unreleased]
-
+### Removed
+- Deprecated Vault login token acquisition steps from init script
 ### Dependencies
 - CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,10 +35,6 @@ ANSIBLE_DIR=/etc/ansible
 export ARA_DEFAULT_LABELS=$SESSION_NAME
 export ARA_RECORD_CONTROLLER=false
 export ARA_RECORD_USER=false
-export VAULT_ENDPOINT=http://cray-vault.vault:8200/v1/auth/kubernetes/login
-export KUBERNETES_JWT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-export ROLE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-export VAULT_TOKEN=$(curl -d '{"jwt": "'"${KUBERNETES_JWT}"'", "role": "'"${ROLE}"'"}' -X POST $VAULT_ENDPOINT | jq '.auth.client_token' | sed -e 's/"//g')
 
 for layer in $(echo "${@}" | jq -c .[]); do
     export SESSION_CLONE_URL=$(echo "${layer}" | jq -r .clone_url)


### PR DESCRIPTION
## Summary and Scope

Removes crufted AEE init steps that do not work regarding lookup and set of vault information related to multi-tenancy decryption.

## Issues and Related PRs

* Resolves [CASMCMS-8893](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8893)


## Risks and Mitigations

The vault token that is retrieved by this init script is not used by tenants. Given that it is not yet used and is not effective, this is a cleanup operation.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

