### PR TITLE
CASMCMS-9466: Reverting back python module updates made in tag `1.19.0` to resolve ansible-core dependency issues with target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ this does, see the README.md entry.
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9466: Reverting back python module updates made in tag `1.19.0` to resolve ansible-core dependency issues with target.
+
+
 ## [1.19.0] - 2025-06-25
 
 ### Dependencies

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,30 +1,30 @@
-ansible-core==2.18.6
-ara==1.7.2 # cfs-ara is using this version. If you need to update it, please check compatibility with cfs-ara.
+ansible-core>=2.11.12,<2.12
+ara>=1.5.8,<1.6
 asn1crypto>=0.24,<0.25
 bcrypt>=3.1.7,<3.2
-certifi==2025.6.15 # certifi 2025.6.15 is dependency of Ara 1.7.2
-cffi==1.17.1 # cffi 1.17.1 is dependency of Ansible 2.18.6
+certifi==2023.7.22
+cffi>=1.17,<1.18
 chardet>=3.0.4,<3.1
-cryptography==45.0.4
+cryptography>=41.0.2,<41.1
 dnspython>=2.0,<2.1
 hvac>=0.9.6,<0.10
-idna==3.10.0 # idna 3.10.0 is dependency of Ara 1.7.2
-Jinja2==3.1.6 # Jinja2 3.1.6 is dependency of Ansible 2.18.6
+idna>=2.8,<2.9
+Jinja2>=2.10.3,<2.11
 jmespath>=0.9.5,<0.10
 # CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
 kubernetes>=24.2,<24.3
-MarkupSafe==3.0.2
+MarkupSafe>=1.1.1,<1.2
 netaddr>=0.7.20,<0.8
 openshift>=0.13.2,<0.14
 paramiko>=2.7.2,<2.8
 pexpect>=4.6,<4.7
 ptyprocess>=0.6,<0.7
 pyasn1>=0.4.8,<0.5
-pycparser==2.22.0
+pycparser>=2.19,<2.20
 PyNaCl>=1.3,<1.4
-PyYAML==6.0.2 # PyYAML 6.0.2 is dependency of Ansible 2.18.6
+PyYAML>=6.0,<6.1
 redis>=3.2.1,<3.3
-requests==2.32.4 # requests 2.32.4 is dependency of Ara 1.7.2
+requests>=2.22,<2.23
 rsa>=4.7.2,<4.8
 six>=1.11,<1.12
-urllib3==2.5.0 # urllib3 2.5.0 is dependency of Ara 1.7.2
+urllib3>=1.25.11,<1.26


### PR DESCRIPTION
CASMCMS-9466: Reverting back python module updates made in tag `1.19.0` to resolve ansible-core dependency issues with target.

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

