### PR TITLE
CASMCMS-9474: Import CA certs during entrypoint setup, if provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ this does, see the README.md entry.
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9474: Import CA certs during entrypoint setup, if provided
+
 ### Dependencies
 - Bump `kubernetes` module version to match CSM 1.7 Kubernetes version
 

--- a/entrypoint-setup.sh
+++ b/entrypoint-setup.sh
@@ -34,7 +34,15 @@ GROUPVARS_DIR=${INVENTORY_DIR}/group_vars
 GROUPVARS_FILE=${GROUPVARS_DIR}/all
 CRAY_GROUPVARS_FILE=${GROUPVARS_FILE}/cray_cfs_environment.yaml
 INVENTORY_COMPLETE_FILE=/inventory/complete
+CRAY_CA_CERT=/etc/cray/ca/certificate_authority.crt
 
+# Update certs if SSL_CAINFO is set
+if [ -v SSL_CAINFO ] && [ -f "${SSL_CAINFO}" ]; then
+    CERTNAME=$(basename "${SSL_CAINFO}")
+    CERTLINK=$(mktemp -p /etc/pki/trust/anchors "XXXXXX.${CERTNAME}")
+    ln -sfv "${SSL_CAINFO}" "${CERTLINK}"
+    update-ca-certificates -v
+fi
 
 # Copy the immutable content mounted in the inventory directory into the ansible
 # inventory directory. This can be a no-op (there isn't any custom config content

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -134,7 +134,7 @@ done
 run_cmd_retry zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URI}" csm-sles
 run_cmd_retry zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URI}" csm-noos
 run_cmd_retry zypper --non-interactive --gpg-auto-import-keys refresh
-run_cmd_retry zypper --non-interactive in --no-confirm python311-devel python311-pip gcc libopenssl-devel openssh less catatonit rsync glibc-locale-base jq
+run_cmd_retry zypper --non-interactive in --no-confirm python311-devel python311-pip gcc libopenssl-devel openssh less catatonit rsync glibc-locale-base jq ca-certificates
 run_cmd_retry zypper --non-interactive in -f --no-confirm csm-ssh-keys-${CSM_SSH_KEYS_VERSION}
 # Lock the version of csm-ssh-keys, just to be certain it is not upgraded inadvertently somehow later
 run_cmd_retry zypper --non-interactive al csm-ssh-keys


### PR DESCRIPTION
[CASMTRIAGE-8351](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8351) was opened because a CFS session using the new SOPS enablement was failing with a certificate error when trying to access Vault. The identical API call worked from inside the ansible container, if I copied in the system CA certificates and used those. I consulted with Joel (who implemented the SOPS feature for CFS) and he agreed that providing the CA certs in the ansible container is the best way to address this.

This requires 2 PRs. This one modifies the AEE image in 2 ways:
1. Ensure that the `ca-certificates` package is installed (so we have the `update-ca-certificates` tool). The output of the install command reports that it is already present, so this isn't actually changing the image, but I wanted to make sure it was installed.
2. In the entrypoint setup script, if the `SSL_CAINFO` environment variable is set and points to a file, then import it into the system certificates.

The other PR is to cfs-operator, and it ensures that the above environment variable is set and points to the certs.

I have tested on wasp with both of these PRs in place, and it resolves the issue that was reported.